### PR TITLE
Replace the uncommon word with a common one

### DIFF
--- a/jekyll/_cci2/certificates.md
+++ b/jekyll/_cci2/certificates.md
@@ -81,7 +81,7 @@ If you're using Route 53 for your DNS records, adding a TXT record is straightfo
 
 ### Using Self-Signed Certificates
 
-Because the ELB does not require a _current_ certificate, you may choose to generate a self-signed certificate with an arbritatry duration.
+Because the ELB does not require a _current_ certificate, you may choose to generate a self-signed certificate with an arbitrary duration.
 
 1. Generate the certificate and key using openssl command `openssl req -newkey rsa:2048 -nodes -keyout key.pem -x509 -days 1 -out certificate.pem`
 


### PR DESCRIPTION
# Description
The uncommon word,`arbritatry` can be `arbitrary` in this context.

# Reasons
I suspect that was just a typo.